### PR TITLE
fix(EIP): Change some parameters from strings to arrays in the List API

### DIFF
--- a/openstack/networking/v1/eips/requests.go
+++ b/openstack/networking/v1/eips/requests.go
@@ -105,10 +105,18 @@ type ListOpts struct {
 	IPVersion int `q:"ip_version"`
 
 	// Associated port id
-	PortId string `q:"port_id"`
+	PortId []string `q:"port_id"`
 
 	// Public IP address
-	PublicIp string `q:"public_ip_address"`
+	PublicIp []string `q:"public_ip_address"`
+
+	// private IP address
+	PrivateIp []string `q:"private_ip_address"`
+
+	// ID
+	Id []string `q:"id"`
+
+	AllowShareBandwidthTypeAny []string `q:"allow_share_bandwidth_type_any"`
 
 	// enterprise_project_id
 	// You can use this field to filter the elastic public IP under an enterprise project.

--- a/openstack/networking/v1/eips/results.go
+++ b/openstack/networking/v1/eips/results.go
@@ -29,19 +29,23 @@ func (r ApplyResult) Extract() (PublicIp, error) {
 
 //PublicIp is a struct that represents a public ip
 type PublicIp struct {
-	ID                  string `json:"id"`
-	Status              string `json:"status"`
-	Type                string `json:"type"`
-	PublicAddress       string `json:"public_ip_address"`
-	PrivateAddress      string `json:"private_ip_address"`
-	PortID              string `json:"port_id"`
-	TenantID            string `json:"tenant_id"`
-	OrderID             string `json:"order_id"`
-	CreateTime          string `json:"create_time"`
-	BandwidthID         string `json:"bandwidth_id"`
-	BandwidthSize       int    `json:"bandwidth_size"`
-	BandwidthShareType  string `json:"bandwidth_share_type"`
-	EnterpriseProjectID string `json:"enterprise_project_id"`
+	ID                         string `json:"id"`
+	Status                     string `json:"status"`
+	Type                       string `json:"type"`
+	PublicAddress              string `json:"public_ip_address"`
+	PublicIpv6Address          string `json:"public_ipv6_address"`
+	PrivateAddress             string `json:"private_ip_address"`
+	PortID                     string `json:"port_id"`
+	TenantID                   string `json:"tenant_id"`
+	OrderID                    string `json:"order_id"`
+	CreateTime                 string `json:"create_time"`
+	BandwidthID                string `json:"bandwidth_id"`
+	BandwidthSize              int    `json:"bandwidth_size"`
+	BandwidthShareType         string `json:"bandwidth_share_type"`
+	EnterpriseProjectID        string `json:"enterprise_project_id"`
+	IpVersion                  string `json:"ip_version"`
+	Alias                      string `json:"alias"`
+	AllowShareBandwidthTypeAny string `json:"allow_share_bandwidth_types"`
 }
 
 //GetResult is a return struct of get method


### PR DESCRIPTION
FIX the API: query EIPs 
1. Change some parameters from strings to arrays:PortId/PublicIp/PrivateId
2.  add some parameter: id/AllowShareBandwidthTypeAny/alias/IpVersion/PublicIpv6Address